### PR TITLE
Add additional check to `any_active_reviews_cycles?`

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,7 @@ class User < ApplicationRecord
   end
 
   def any_active_reviews_cycles?
-    active_reviews_cycles.count >= 1
+    active_reviews_cycles.count >= 1 && active_reviews_cycles.last.enabled?
   end
 
   def reviews_cycles_list


### PR DESCRIPTION
Because I've now opened up for orgadmins to edit a review cycle that
has review request date greater than today, I'd like to ensure that
this helper method won't return true if the latest reviews cycle is not
enabled.