### PR TITLE
Notify users by email upon enabling a reviews cycle

### DIFF
--- a/app/controllers/reviews_cycles_controller.rb
+++ b/app/controllers/reviews_cycles_controller.rb
@@ -29,6 +29,7 @@ class ReviewsCyclesController < ApplicationController
     respond_to do |format|
       if @reviews_cycle.save
         assign_users_to_review_cycle(@reviews_cycle)
+        send_notification_by_email
         format.html { redirect_to reviews_cycle_url(@reviews_cycle), notice: 'Reviews cycle was successfully created.' }
         format.json { render :show, status: :created, location: @reviews_cycle }
       else
@@ -41,6 +42,7 @@ class ReviewsCyclesController < ApplicationController
   def update
     respond_to do |format|
       if @reviews_cycle.update(reviews_cycle_params)
+        send_notification_by_email
 
         format.html do
           redirect_to reviews_cycle_url(@reviews_cycle), notice: 'Reviews cycle was successfully updated.'
@@ -80,5 +82,11 @@ class ReviewsCyclesController < ApplicationController
 
   def org_has_active_reviews_cycles?
     current_organisation.reviews_cycles&.any? { |cycle| cycle.enabled? }
+  end
+
+  def send_notification_by_email
+    return unless @reviews_cycle.enabled?
+
+    ReviewsCycleMailer.notify_user(@reviews_cycle).deliver_now
   end
 end

--- a/app/mailers/reviews_cycle_mailer.rb
+++ b/app/mailers/reviews_cycle_mailer.rb
@@ -1,0 +1,10 @@
+class ReviewsCycleMailer < ApplicationMailer
+  def notify_user(reviews_cycle)
+    @reviews_cycle = reviews_cycle
+    users = reviews_cycle.users
+
+    users.each do |user|
+      mail(to: user.email, subject: 'You have been invited to submit a review')
+    end
+  end
+end

--- a/app/models/reviews_cycle.rb
+++ b/app/models/reviews_cycle.rb
@@ -15,6 +15,8 @@ class ReviewsCycle < ApplicationRecord
   validates :deadline, presence: true
   validates :name, presence: true
 
+  after_save :update_notification_status
+
   def locked?
     review_request_date.present? && review_request_date <= Date.today
   end
@@ -27,7 +29,11 @@ class ReviewsCycle < ApplicationRecord
     locked? && deadline.present? && deadline >= Date.today
   end
 
-  def disabled?
-    !enabled
+  def update_notification_status
+    if enabled?
+      true
+    else
+      false
+    end
   end
 end

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -2,11 +2,7 @@
 <html>
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <style>
-      /* Email styles need to be inline */
-    </style>
   </head>
-
   <body>
     <%= yield %>
   </body>

--- a/app/views/reviews_cycle_mailer/notify_user.html.erb
+++ b/app/views/reviews_cycle_mailer/notify_user.html.erb
@@ -1,0 +1,11 @@
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h1> You have been invited to submit a review for <%= @reviews_cycle.name %>! </h1>
+    <p>
+      <%= link_to 'Visit your dashboard', root_url %>
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
If upon creating or editing a reviews cycle it becomes enabled, then a
user will receive an email inviting them to fill out a review.

Currently, if a review is only enabled later, there's no background job
running that will perform the task as it should. This is an implementation
for future iterations.